### PR TITLE
Cache Grafana API (Vercel) + fix mobile x-axis labels

### DIFF
--- a/app/api/grafana-data/route.ts
+++ b/app/api/grafana-data/route.ts
@@ -75,10 +75,19 @@ export async function GET() {
         lastUpdated: new Date().toISOString()
       };
 
-      return NextResponse.json(responseData);
+      return NextResponse.json(responseData, {
+        headers: {
+          // Vercel/edge caching: serve cached data fast, and refresh in background when stale.
+          'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=86400'
+        }
+      });
     }
     
-    return NextResponse.json(data);
+    return NextResponse.json(data, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=86400'
+      }
+    });
   } catch (error) {
     console.error('Error fetching Grafana data:', error);
     return NextResponse.json(


### PR DESCRIPTION
- Adds Cache-Control: public, s-maxage=600, stale-while-revalidate=86400 to /api/grafana-data so new/incognito visitors usually get cached data instantly and Vercel refreshes in the background.\n- Improves chart mobile axis scaling to avoid overlapping month labels.